### PR TITLE
refactor: Update byId function for typed object returns

### DIFF
--- a/src/modules/ui/options.ts
+++ b/src/modules/ui/options.ts
@@ -5,10 +5,10 @@ import {precreatedHeightmaps} from "config/precreated-heightmaps";
 import {lock, locked, unlock} from "scripts/options/lock";
 import {clearMainTip, tip} from "scripts/tooltips";
 import {last} from "utils/arrayUtils";
-import {applyDropdownOption, HtmlWrapper} from "utils/nodeUtils";
+import {applyDropdownOption, byId } from "utils/nodeUtils";
 import {minmax, rn} from "utils/numberUtils";
 import {gauss, P, rand, rw} from "utils/probabilityUtils";
-import {byId, stored} from "utils/shorthands";
+import {stored} from "utils/shorthands";
 import {regenerateMap} from "scripts/generation/generation";
 // @ts-expect-error js file
 import {fitScaleBar} from "modules/measurers.js";
@@ -34,62 +34,60 @@ const COA = window.COA;
 const tooltip = byId("tooltip")! as HTMLDivElement;
 
 // Options pane elements
-const optionsTrigger = byId("optionsTrigger")! as HTMLButtonElement;
-const regenerate = byId("regenerate")! as HTMLButtonElement;
-const optionsDiv = byId("optionsContainer")! as HTMLDivElement;
-// const optionsDiv = new HtmlWrapper<"",HTMLDivElement>("optionsContainer");
-const collapsible = byId("collapsible")! as HTMLDivElement;
-const layersContent = byId("layersContent")! as HTMLDivElement;
-const styleContent = byId("styleContent")! as HTMLDivElement;
-const customizationMenu = byId("customizationMenu")! as HTMLDivElement;
-const toolsContent = byId("toolsContent")! as HTMLDivElement;
-const aboutContent = byId("aboutContent")! as HTMLDivElement;
-const optionsContent = byId("optionsContent")! as HTMLDivElement;
-const alertMessage = byId("alertMessage")! as HTMLDivElement;
-// const dialogDiv = byId("dialogs")! as HTMLDivElement;
-const dialogDiv = new HtmlWrapper<"Content">("dialogs");
+const optionsTrigger = byId<'button'>("optionsTriggerr");
+const regenerate = byId<'button'>("regenerate");
+const optionsDiv = byId<'div'>("optionsContainer");
+const collapsible = byId<'div'>("collapsible");
+const layersContent = byId<'div'>("layersContent");
+const styleContent = byId<'div'>("styleContent");
+const customizationMenu = byId<'div'>("customizationMenu");
+const toolsContent = byId<'div'>("toolsContent");
+const aboutContent = byId<'div'>("aboutContent");
+const optionsContent = byId<'div'>("optionsContent");
+const alertMessage = byId<'div'>("alertMessage");
+const dialogDiv = byId<'div'>("dialogs");
+
 // Number inputs
-// const themeColorInput = byId("themeColorInput")! as HTMLInputElement;
-const themeColorInput = new HtmlWrapper("themeColorInput")
-const themeHueInput = byId("themeHueInput")! as HTMLInputElement;
+const themeColorInput = byId<'input'>("themeColorInput");
+const themeHueInput = byId<'input'>("themeHueInput");
 
-const transparencyInput = byId("transparencyInput")! as HTMLInputElement;
-const transparencyOutput = byId("transparencyOutput")! as HTMLInputElement;
+const transparencyInput = byId<'input'>("transparencyInput");
+const transparencyOutput = byId<'input'>("transparencyOutput");
 
-const mapWidthInput = byId("mapWidthInput")! as HTMLInputElement;
-const mapHeightInput = byId("mapHeightInput")! as HTMLInputElement;
+const mapWidthInput = byId<'input'>("mapWidthInput");
+const mapHeightInput = byId<'input'>("mapHeightInput");
 
-const zoomExtentMin = byId("zoomExtentMin")! as HTMLInputElement;
-const zoomExtentMax = byId("zoomExtentMax")! as HTMLInputElement;
+const zoomExtentMin = byId<'input'>("zoomExtentMin");
+const zoomExtentMax = byId<'input'>("zoomExtentMax");
 
-const optionsSeed = byId("optionsSeed")! as HTMLInputElement;
-const pointsInput = byId("pointsInput")! as HTMLInputElement;
+const optionsSeed = byId<'input'>("optionsSeed");
+const pointsInput = byId<'input'>("pointsInput");
 
-const culturesInput = byId("culturesInput")! as HTMLInputElement;
-const regionsOutput = byId("regionsOutput")! as HTMLInputElement;
+const culturesInput = byId<'input'>("culturesInput");
+const regionsOutput = byId<'input'>("regionsOutput");
 
-const uiSizeInput = byId("uiSizeInput")! as HTMLInputElement;
-const uiSizeOutput = byId("uiSizeOutput")! as HTMLInputElement;
+const uiSizeInput = byId<'input'>("uiSizeInput");
+const uiSizeOutput = byId<'input'>("uiSizeOutput");
 
-const distanceUnitInput = byId("distanceUnitInput")! as HTMLSelectElement;
-const heightUnitInput = byId("heightUnitInput")! as HTMLSelectElement;
+const distanceUnitInput = byId<'select'>("distanceUnitInput");
+const heightUnitInput = byId<'select'>("heightUnitInput");
 
-const regionsInput = byId("regionsInput")! as HTMLInputElement;
+const regionsInput = byId<'input'>("regionsInput");
 
 // Text inputs
-const mapName = new HtmlWrapper<"Input", string>("mapName");
-const templateInput = byId("templateInput")! as HTMLSelectElement
-const culturesSet = byId("culturesSet")! as HTMLSelectElement;
-const culturesOutput = byId("culturesOutput")! as HTMLInputElement;
+const mapName = byId<"input">("mapName");
+const templateInput = byId<'select'>("templateInput")
+const culturesSet = byId<'select'>("culturesSet");
+const culturesOutput = byId<'input'>("culturesOutput");
 
-const stylePreset = byId("stylePreset")! as HTMLSelectElement;
+const stylePreset = byId<'select'>("stylePreset");
 
-const shapeRendering = byId("shapeRendering")! as HTMLSelectElement;
-const stateLabelsModeInput = byId("stateLabelsModeInput")! as HTMLSelectElement;
+const shapeRendering = byId<'select'>("shapeRendering");
+const stateLabelsModeInput = byId<'select'>("stateLabelsModeInput");
 
 // Outputs
-const manorsOutput = byId("manorsOutput")! as HTMLOutputElement;
-const pointsOutputFormatted = byId("pointsOutputFormatted")! as HTMLOutputElement;
+const manorsOutput = byId<'output'>("manorsOutput");
+const pointsOutputFormatted = byId<'output'>("pointsOutputFormatted");
 
 
 // remove glow if tip is aknowledged

--- a/src/modules/ui/options.ts
+++ b/src/modules/ui/options.ts
@@ -5,7 +5,7 @@ import {precreatedHeightmaps} from "config/precreated-heightmaps";
 import {lock, locked, unlock} from "scripts/options/lock";
 import {clearMainTip, tip} from "scripts/tooltips";
 import {last} from "utils/arrayUtils";
-import {applyDropdownOption} from "utils/nodeUtils";
+import {applyDropdownOption, HtmlWrapper} from "utils/nodeUtils";
 import {minmax, rn} from "utils/numberUtils";
 import {gauss, P, rand, rw} from "utils/probabilityUtils";
 import {byId, stored} from "utils/shorthands";
@@ -36,7 +36,8 @@ const tooltip = byId("tooltip")! as HTMLDivElement;
 // Options pane elements
 const optionsTrigger = byId("optionsTrigger")! as HTMLButtonElement;
 const regenerate = byId("regenerate")! as HTMLButtonElement;
-const optionsDiv = byId("options")! as HTMLDivElement;
+const optionsDiv = byId("optionsContainer")! as HTMLDivElement;
+// const optionsDiv = new HtmlWrapper<"",HTMLDivElement>("optionsContainer");
 const collapsible = byId("collapsible")! as HTMLDivElement;
 const layersContent = byId("layersContent")! as HTMLDivElement;
 const styleContent = byId("styleContent")! as HTMLDivElement;
@@ -45,10 +46,11 @@ const toolsContent = byId("toolsContent")! as HTMLDivElement;
 const aboutContent = byId("aboutContent")! as HTMLDivElement;
 const optionsContent = byId("optionsContent")! as HTMLDivElement;
 const alertMessage = byId("alertMessage")! as HTMLDivElement;
-const dialogDiv = byId("dialogs")! as HTMLDivElement;
-
+// const dialogDiv = byId("dialogs")! as HTMLDivElement;
+const dialogDiv = new HtmlWrapper<"Content">("dialogs");
 // Number inputs
-const themeColorInput = byId("themeColorInput")! as HTMLInputElement;
+// const themeColorInput = byId("themeColorInput")! as HTMLInputElement;
+const themeColorInput = new HtmlWrapper("themeColorInput")
 const themeHueInput = byId("themeHueInput")! as HTMLInputElement;
 
 const transparencyInput = byId("transparencyInput")! as HTMLInputElement;
@@ -72,8 +74,10 @@ const uiSizeOutput = byId("uiSizeOutput")! as HTMLInputElement;
 const distanceUnitInput = byId("distanceUnitInput")! as HTMLSelectElement;
 const heightUnitInput = byId("heightUnitInput")! as HTMLSelectElement;
 
+const regionsInput = byId("regionsInput")! as HTMLInputElement;
+
 // Text inputs
-const mapName = byId("mapName")! as HTMLInputElement;
+const mapName = new HtmlWrapper<"Input", string>("mapName");
 const templateInput = byId("templateInput")! as HTMLSelectElement
 const culturesSet = byId("culturesSet")! as HTMLSelectElement;
 const culturesOutput = byId("culturesOutput")! as HTMLInputElement;

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -1,4 +1,40 @@
-import {byId} from "./shorthands";
+export type ElementMap = {
+  a: HTMLAnchorElement;
+  button: HTMLButtonElement;
+  div: HTMLDivElement;
+  img: HTMLImageElement;
+  input: HTMLInputElement;
+  output: HTMLOutputElement;
+  select: HTMLSelectElement;
+  // add more types as needed
+};
+
+type ElementMapKeys = keyof ElementMap;
+
+interface ByIdOptions {
+  throwOnNull?: boolean;
+  // add more options as needed
+}
+
+// function definition with overloads to account for different options
+export function byId<K extends ElementMapKeys>(id: string, options?: ByIdOptions & {throwOnNull: true}): ElementMap[K];
+export function byId<K extends ElementMapKeys>(id: string, options: ByIdOptions & {throwOnNull: boolean}): ElementMap[K]|null;
+/**
+ * Retrieves an element from the DOM by its ID.
+ * @template K - The key of the element in the ElementMap.
+ * @param {string} id - The ID of the element to retrieve.
+ * @param {ByIdOptions} [options] - The options for retrieving the element.
+ * @param {boolean} [options.throwOnNull=true] - Whether to throw an error if the element is not found.
+ * @returns {ElementMap[K] | null} The retrieved element or null if not found.
+ * @throws {Error} If the element is not found and options.throwOnNull is true.
+ */
+export function byId<K extends ElementMapKeys>(id: string, options: ByIdOptions = {throwOnNull: true}) {
+  const element = document.getElementById(id);
+  if (!element && options.throwOnNull) {
+    throw new Error(`Element ${id} not found`);
+  } 
+  return element as ElementMap[K] | null;
+}
 
 // get next unused id
 export function getNextId(core: string, index = 1) {
@@ -42,85 +78,4 @@ export function applyDropdownOption($select: HTMLSelectElement, value: string, n
   const isExisting = Array.from($select.options).some(o => o.value === value);
   if (!isExisting) $select.options.add(new Option(name, value));
   $select.value = value;
-}
-
-type ElementPredictor<N extends string> = 
-N extends `${string}Content` ? HTMLDivElement :
-N extends `${string}Trigger` ? HTMLButtonElement :
-N extends `${string}Options` ? HTMLSelectElement :
-N extends `${string}ColorInput` ? HTMLInputElement :
-N extends `${string}Input` ? HTMLInputElement :
-N extends `${string}Output` ? HTMLInputElement :
-HTMLElement;
-type TypePredictor<N extends string> = 
-N extends `${string}Content` ? never :
-N extends `${string}Trigger` ? string :
-N extends `${string}Options` ? string :
-N extends `${string}ColorInput` ? string :
-N extends `${string}Input` ? number :
-N extends `${string}Output` ? number :
-never;
-
-
-
-/**
- * Represents an HTML wrapper class.
- * Type is inferred from the ID naming.
- * Provides typing for valueed input elements.
- * @template IDTYPE - The type of the element's ID.
- * @template ElemType - The type of the HTML element.
- * @template ValType - The type of the element's value.
- * @argument id - The ID of the element.
- * 
- * @example
- * // infered types
- * const input = new HtmlWrapper("someInput"); // Is an HTMLInputElement and its value is number by default
- * const stringInput = new HtmlWrapper<"",string>("someStringInput"); // Is an HTMLInputElement and its value is string
- * 
- * @example
- * // explicit types
- * const inputThatIsNotNamedCorrectly = new HtmlWrapper<"Input",string>("someString"); // Is an HTMLInputElement and its value is number
- * // OR
- * const inputThatIsNotNamedCorrectly = new HtmlWrapper<"",string,HTMLInputElement>("someString"); // Is an HTMLInputElement and its value is string
- * 
- */
-export class HtmlWrapper<IDTYPE extends string = "", ValType = TypePredictor<IDTYPE>, ElemType extends HTMLElement = ElementPredictor<IDTYPE>>{
-  // OPTIMIZATION: avoid duplicate DOM queries
-  // static cache to store instances - class global
-  static cache: Record<string, HtmlWrapper<any,any,any>> = {};
-  
-  // Member variables
-  #element!: ElemType;
-  
-  // Member functions
-  // Uses the IDTYPE to infer the type of the element
-  constructor(id: IDTYPE | string){
-    if(HtmlWrapper.cache[id] !== undefined){
-      return HtmlWrapper.cache[id];
-    }
-    this.#element = byId(id) as ElemType;
-    if (!this.#element) throw new Error(`Element ${id} not found`);
-    HtmlWrapper.cache[id] = this;
-  }
-
-  get element(){
-    return this.#element;
-  }
-
-  get value() {
-    return (this.#element as unknown as HTMLInputElement)?.value as unknown as ValType;
-  }
-
-  set value(v:ValType) {
-    (this.#element as unknown as HTMLInputElement).value = v as any;
-  }
-
-  get style() {
-    return this.#element.style;
-  }
-  
-  on(event: string, callback: (e: Event) => void) {
-    this.#element.addEventListener(event, callback);
-  }
-
 }


### PR DESCRIPTION
Provides an HTML Wrapper class for commonly used HTML Elements to ensure that typing is reflected properly to the code element. The match of type is done at best afford by the naming of the property. This can be overwritten vy providing the necessary types during initialization.